### PR TITLE
fix: remove extra bracket

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,6 @@ jobs:
           fi
           echo "Existing version has not been published"
           aws s3 cp ./ps-postprocess s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}/linux/amd64/ps-postprocess
-          aws s3 cp ./ps-postprocess.exe s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}}/windows/amd64/ps-postprocess.exe
-          aws s3 cp ./ps-postprocess-darwin s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}}/darwin/amd64/ps-postprocess
-          aws s3 cp ./licenses.json s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}}/licenses.json
+          aws s3 cp ./ps-postprocess.exe s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}/windows/amd64/ps-postprocess.exe
+          aws s3 cp ./ps-postprocess-darwin s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}/darwin/amd64/ps-postprocess
+          aws s3 cp ./licenses.json s3://${{env.BUCKET_NAME}}/ps-postprocess/${{steps.get-version.outputs.version}}/licenses.json


### PR DESCRIPTION
causing } to be in the S3 key

![image](https://github.com/MosaicManufacturing/ps-postprocess/assets/4390467/33011207-11a7-41fa-bc4b-e37ccda2aece)
